### PR TITLE
Add client methods for new data API endpoints

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Carlos Andrés Rocha <rocha@edx.org>
 Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Gabe Mulley <gabe@edx.org>
+Dylan Rhodes <dylanr@stanford.edu>

--- a/analyticsclient/client.py
+++ b/analyticsclient/client.py
@@ -6,6 +6,7 @@ from analyticsclient.constants import data_format as DF
 
 from analyticsclient.course import Course
 from analyticsclient.exceptions import ClientError, InvalidRequestError, NotFoundError, TimeoutError
+from analyticsclient.module import Module
 from analyticsclient.status import Status
 
 
@@ -40,6 +41,7 @@ class Client(object):
 
         self.status = Status(self)
         self.courses = lambda course_id: Course(self, course_id)
+        self.modules = lambda course_id, module_id: Module(self, course_id, module_id)
 
     def get(self, resource, timeout=None, data_format=DF.JSON):
         """

--- a/analyticsclient/module.py
+++ b/analyticsclient/module.py
@@ -1,0 +1,51 @@
+import analyticsclient.constants.data_format as DF
+
+
+class Module(object):
+    """ Module related analytics data. """
+
+    def __init__(self, client, course_id, module_id):
+        """
+        Initialize the Module client.
+
+        Arguments:
+            client (analyticsclient.client.Client): The client to use to access the API.
+            course_id (str): String identifying the course
+            module_id (str): String identifying the module
+        """
+        self.client = client
+        self.course_id = unicode(course_id)
+        self.module_id = unicode(module_id)
+
+    def answer_distribution(self, data_format=DF.JSON):
+        """
+        Get answer distribution data for a module.
+
+        Arguments:
+            data_format (str): Format in which to return data (default is JSON)
+        """
+        path = 'problems/{0}/answer_distribution/'.format(self.module_id)
+
+        return self.client.get(path, data_format=data_format)
+
+    def grade_distribution(self, data_format=DF.JSON):
+        """
+        Get grade distribution data for a module.
+
+        Arguments:
+            data_format (str): Format in which to return data (default is JSON)
+        """
+        path = 'problems/{0}/grade_distribution/'.format(self.module_id)
+
+        return self.client.get(path, data_format=data_format)
+
+    def sequential_open_distribution(self, data_format=DF.JSON):
+        """
+        Get open distribution data for a module.
+
+        Arguments:
+            data_format (str): Format in which to return data (default is JSON)
+        """
+        path = 'problems/{0}/sequential_open_distribution/'.format(self.module_id)
+
+        return self.client.get(path, data_format=data_format)

--- a/analyticsclient/tests/test_module.py
+++ b/analyticsclient/tests/test_module.py
@@ -1,0 +1,96 @@
+import json
+import httpretty
+
+from analyticsclient.tests import ClientTestCase
+
+
+class ModulesTests(ClientTestCase):
+    def setUp(self):
+        super(ModulesTests, self).setUp()
+        httpretty.enable()
+
+        self.course_id = 'edX/TestX/TestCourse'
+        self.module_id = 'i4x://TestCourse/block1/module2/abcd1234'
+
+        self.module = self.client.modules(self.course_id, self.module_id)
+
+    def tearDown(self):
+        super(ModulesTests, self).tearDown()
+        httpretty.disable()
+
+    def test_open_distribution_url(self):
+        """ Verifies that the sequential open URL is correct. """
+        uri = self.get_api_url('problems/{0}/sequential_open_distribution/'.format(self.module_id))
+
+        httpretty.register_uri(httpretty.GET, uri, body='{}')
+        self.module.sequential_open_distribution()
+
+    def test_answer_distribution_url(self):
+        """ Verifies that the answer distribution URL is correct. """
+        uri = self.get_api_url('problems/{0}/answer_distribution/'.format(self.module_id))
+
+        httpretty.register_uri(httpretty.GET, uri, body='{}')
+        self.module.answer_distribution()
+
+    def test_grade_distribution_url(self):
+        """ Verifies that the grade distribution URL is correct. """
+        uri = self.get_api_url('problems/{0}/grade_distribution/'.format(self.module_id))
+
+        httpretty.register_uri(httpretty.GET, uri, body='{}')
+        self.module.grade_distribution()
+
+    @httpretty.activate
+    def test_open_distribution_response(self):
+        """ Verifies that open distribution responds with the expected values. """
+        body = [
+            {
+                'course_id': self.course_id,
+                'module_id': self.module_id,
+                'count': 123,
+                'created': '2014-01-01T00:00:00Z'
+            }
+        ]
+
+        uri = self.get_api_url('problems/{0}/sequential_open_distribution/'.format(self.module_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.module.sequential_open_distribution())
+
+    @httpretty.activate
+    def test_answer_distribution_response(self):
+        """ Verifies that answer distribution responds with the expected values. """
+        body = [
+            {
+                'course_id': self.course_id,
+                'module_id': self.module_id,
+                'part_id': self.module_id.replace('/', '-') + '-part1',
+                'correct': True,
+                'count': 2,
+                'value_id': 'choice_4',
+                'answer_value_text': 'User chose this answer.',
+                'answer_value_numeric': None,
+                'variant': 123,
+                'created': "2014-01-01T00:01:00"
+            }
+        ]
+
+        uri = self.get_api_url('problems/{0}/answer_distribution/'.format(self.module_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.module.answer_distribution())
+
+    @httpretty.activate
+    def test_grade_distribution_response(self):
+        """ Verifies that the grade distribution responds with the expected values. """
+        body = [
+            {
+                'module_id': self.module_id,
+                'course_id': self.course_id,
+                'grade': 0,
+                'max_grade': 1,
+                'count': 1,
+                'created': '2014-01-01T00:01:00'
+            }
+        ]
+
+        uri = self.get_api_url('problems/{0}/grade_distribution/'.format(self.module_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.module.grade_distribution())


### PR DESCRIPTION
This implements client methods for the sequential open distribution, grade distribution, and answer distribution API methods which were merged into the data API a few weeks ago.  It also includes test cases for the new client methods.  @dsjen and I are planning to use these elsewhere in the platform in the near future, so it would be nice to have some reviews on it this week when you guys are free.  As always, feedback is encouraged.  Thanks everyone! @jbau @clintonb @rocha 
