### PR TITLE
remove httpretty python constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,11 +6,11 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.12
     # via requests
 idna==3.3
     # via requests
-requests==2.26.0
+requests==2.27.1
     # via -r requirements/base.in
-urllib3==1.26.7
+urllib3==1.26.9
     # via requests

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,4 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
- 
-# When we went from httpretty 0.9.7 to 1.0.2, tests broke
-httpretty<1.0.0
+

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,24 +4,26 @@
 #
 #    make upgrade
 #
-astroid==2.8.5
+astroid==2.11.3
     # via pylint
-attrs==21.2.0
+attrs==21.4.0
     # via pytest
 certifi==2021.10.8
     # via
     #   -r requirements/base.txt
     #   requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.12
     # via
     #   -r requirements/base.txt
     #   requests
-coverage[toml]==6.1.2
+coverage[toml]==6.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
 ddt==1.4.4
     # via -r requirements/test.in
+dill==0.3.4
+    # via pylint
 httpretty==0.9.7
     # via
     #   -c requirements/constraints.txt
@@ -34,13 +36,13 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-lazy-object-proxy==1.6.0
+lazy-object-proxy==1.7.1
     # via astroid
-mccabe==0.6.1
+mccabe==0.7.0
     # via pylint
 packaging==21.3
     # via pytest
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via pylint
 pluggy==1.0.0
     # via pytest
@@ -50,39 +52,38 @@ pycodestyle==2.8.0
     # via -r requirements/test.in
 pydocstyle==6.1.1
     # via -r requirements/test.in
-pylint==2.11.1
+pylint==2.13.7
     # via -r requirements/test.in
-pyparsing==3.0.6
+pyparsing==3.0.8
     # via packaging
-pytest==6.2.5
+pytest==7.1.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
 pytest-cov==3.0.0
     # via -r requirements/test.in
-requests==2.26.0
+requests==2.27.1
     # via -r requirements/base.txt
 six==1.16.0
     # via httpretty
 snowballstemmer==2.2.0
     # via pydocstyle
-testfixtures==6.18.3
+testfixtures==6.18.5
     # via -r requirements/test.in
-toml==0.10.2
+tomli==2.0.1
     # via
+    #   coverage
     #   pylint
     #   pytest
-tomli==1.2.2
-    # via coverage
-typing-extensions==4.0.0
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.7
+urllib3==1.26.9
     # via
     #   -r requirements/base.txt
     #   requests
-wrapt==1.13.3
+wrapt==1.14.0
     # via astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,10 +24,8 @@ ddt==1.4.4
     # via -r requirements/test.in
 dill==0.3.4
     # via pylint
-httpretty==0.9.7
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.in
+httpretty==1.1.4
+    # via -r requirements/test.in
 idna==3.3
     # via
     #   -r requirements/base.txt
@@ -64,8 +62,6 @@ pytest-cov==3.0.0
     # via -r requirements/test.in
 requests==2.27.1
     # via -r requirements/base.txt
-six==1.16.0
-    # via httpretty
 snowballstemmer==2.2.0
     # via pydocstyle
 testfixtures==6.18.5

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,25 +4,23 @@
 #
 #    make upgrade
 #
-backports.entry-points-selectable==1.1.1
-    # via virtualenv
-coverage==6.1.2
+coverage==6.3.2
     # via -r requirements/tox.in
-distlib==0.3.3
+distlib==0.3.4
     # via virtualenv
-filelock==3.4.0
+filelock==3.6.0
     # via
     #   tox
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.4.0
+platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.6
+pyparsing==3.0.8
     # via packaging
 six==1.16.0
     # via
@@ -30,7 +28,7 @@ six==1.16.0
     #   virtualenv
 toml==0.10.2
     # via tox
-tox==3.24.4
+tox==3.25.0
     # via -r requirements/tox.in
-virtualenv==20.10.0
+virtualenv==20.14.1
     # via tox


### PR DESCRIPTION
httpretty is only used in test, constraint was for breaking tests, and the tests are working after letting it update to latest