### PR TITLE
fix: add wheel installation for pypi publish action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.8
 
       - name: Install pip
-        run: pip install -U pip
+        run: pip install -U pip wheel
 
       - name: Build package
         run: python setup.py sdist bdist_wheel


### PR DESCRIPTION
The pypi_publish action is failing because `wheel` is not installed.