### PR TITLE
docs: Update the contributing guidelines link.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Contributions are very welcome, but for legal reasons, you must submit a signed
 high code quality, which will make your contribution more likely to be accepted.
 
 .. _individual contributor's agreement: http://code.edx.org/individual-contributor-agreement.pdf
-.. _CONTRIBUTING: https://github.com/openedx/edx-platform/blob/master/CONTRIBUTING.rst
+.. _CONTRIBUTING: https://github.com/openedx/.github/blob/master/CONTRIBUTING.md
 
 .. |build-status| image:: https://github.com/openedx/edx-analytics-data-api-client/workflows/Python%20CI/badge.svg?branch=master
    :target: https://github.com/openedx/edx-analytics-data-api-client/actions?query=workflow%3A%22Python+CI%22


### PR DESCRIPTION
We're moving towards a single set of guidelines org-wide.
